### PR TITLE
feat: tree shaking

### DIFF
--- a/packages/react-charts-donut/tsconfig.json
+++ b/packages/react-charts-donut/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": false,
     "jsx": "react",
     "lib": ["dom", "esnext"],
-    "module": "commonjs",
+    "module": "es6",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noErrorTruncation": false,
@@ -18,7 +18,7 @@
     "pretty": true,
     "removeComments": false,
     "strict": true,
-    "target": "es2015",
+    "target": "es6",
     "useDefineForClassFields": false
   },
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-charts-time-series-complex/tsconfig.json
+++ b/packages/react-charts-time-series-complex/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": false,
     "jsx": "react",
     "lib": ["dom", "esnext"],
-    "module": "commonjs",
+    "module": "es6",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noErrorTruncation": false,
@@ -18,7 +18,7 @@
     "pretty": true,
     "removeComments": false,
     "strict": true,
-    "target": "es2015",
+    "target": "es6",
     "useDefineForClassFields": false
   },
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"],

--- a/packages/react-charts-time-series/tsconfig.json
+++ b/packages/react-charts-time-series/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": false,
     "jsx": "react",
     "lib": ["dom", "esnext"],
-    "module": "commonjs",
+    "module": "es6",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noErrorTruncation": false,
@@ -18,7 +18,7 @@
     "pretty": true,
     "removeComments": false,
     "strict": true,
-    "target": "es2015",
+    "target": "es6",
     "useDefineForClassFields": false
   },
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"],


### PR DESCRIPTION
# Summary

Per this [issue](https://github.com/webpack/webpack.js.org/issues/995#issuecomment-300679434) - we need to use `es6` in order to enable tree shaking.